### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Create a test file `src/add.test.js` and use Node's built-in [`assert`](https://
 
 ```js
 import { strict as assert } from 'assert' // Node <=16
-// import strict from 'assert/strict'  // Node >=16
+// import assert from 'assert/strict'  // Node >=16
 
 export function testAdd() {
   assert.equal(1 + 2, 3)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Create a test file `src/add.test.js` and use Node's built-in [`assert`](https://
 
 ```js
 import { strict as assert } from 'assert' // Node <=16
-// import { equal } from 'assert/strict'  // Node >=16
+// import strict from 'assert/strict'  // Node >=16
 
 export function testAdd() {
   assert.equal(1 + 2, 3)


### PR DESCRIPTION
The alternative import statement in the Usage section should be:
```js
import assert from 'assert/strict'  // Node >=16
```
instead of:
```js
import { equal } from 'assert/strict'  // Node >=16
```
For the following code to work:
```js
export function testAdd() {
  assert.equal(1 + 2, 3)
}