### PR TITLE
export run method

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,44 +1,4 @@
 #!/usr/bin/env node
-import { promises as fs } from 'fs'
-import { basename, join } from 'path'
-import { pathToFileURL } from 'url'
+import xv from './index.js'
 
-async function* walk(dir: string): AsyncGenerator<string> {
-  for await (const d of await fs.opendir(dir)) {
-    const entry = join(dir, d.name)
-    if (d.isDirectory() && d.name !== 'node_modules') yield* walk(entry)
-    else if (d.isFile()) yield entry
-  }
-}
-
-async function runTestFile(file: string): Promise<void> {
-  for (const value of Object.values(
-    await import(pathToFileURL(file).toString()),
-  )) {
-    if (typeof value === 'function') {
-      try {
-        await value()
-      } catch (e) {
-        console.error(e instanceof Error ? e.stack : e)
-        process.exit(1)
-      }
-    }
-  }
-}
-
-async function run(arg = '.') {
-  if ((await fs.lstat(arg)).isFile()) {
-    return runTestFile(arg)
-  }
-  for await (const file of walk(arg)) {
-    if (
-      basename(file) === 'test.js' ||
-      file.endsWith('.test.js')
-    ) {
-      console.log(file)
-      await runTestFile(file)
-    }
-  }
-}
-
-void run(process.argv[2])
+void xv(process.argv[2])

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,41 @@
+import { promises as fs } from 'fs'
+import { basename, join } from 'path'
+import { pathToFileURL } from 'url'
+
+async function* walk(dir: string): AsyncGenerator<string> {
+  for await (const d of await fs.opendir(dir)) {
+    const entry = join(dir, d.name)
+    if (d.isDirectory() && d.name !== 'node_modules') yield* walk(entry)
+    else if (d.isFile()) yield entry
+  }
+}
+
+async function runTestFile(file: string): Promise<void> {
+  for (const value of Object.values(
+    await import(pathToFileURL(file).toString()),
+  )) {
+    if (typeof value === 'function') {
+      try {
+        await value()
+      } catch (e) {
+        console.error(e instanceof Error ? e.stack : e)
+        process.exit(1)
+      }
+    }
+  }
+}
+
+export default async function run(arg = '.') {
+  if ((await fs.lstat(arg)).isFile()) {
+    return runTestFile(arg)
+  }
+  for await (const file of walk(arg)) {
+    if (
+      basename(file) === 'test.js' ||
+      file.endsWith('.test.js')
+    ) {
+      console.log(file)
+      await runTestFile(file)
+    }
+  }
+}


### PR DESCRIPTION
#6 

`package.json` has exported `index.js`, but in fact the file does not exist. Adding this file makes xv available within the file.

**Usage**
```bash
xv(<PATH>)
```