### PR TITLE
fix: package.json remove unused exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "license": "MIT",
   "author": "Typicode <typicode@gmail.com>",
   "type": "module",
-  "exports": "./lib/index.js",
   "types": "lib",
   "bin": "./lib/bin.js",
   "files": [


### PR DESCRIPTION
Remove unused `exports` as pointed out by @linbuxiao in https://github.com/typicode/xv/issues/6 :+1: 